### PR TITLE
ステップ2 パスワードを取得する機能の修正

### DIFF
--- a/password_manager.sh
+++ b/password_manager.sh
@@ -23,13 +23,13 @@ function get_password (){
 
     if [ -n "$accounts" ]; then
         echo "サービス名：${input_service}"
-        for account in $accounts
+        while read account;
         do
             user=$(echo "$account" | cut -d':' -f2)
             password=$(echo "$account" | cut -d':' -f3)
             echo "ユーザー名：${user}"
             echo "パスワード：${password}"
-        done
+        done <<< "${accounts}"
     else
         echo "そのサービスは登録されていません。"
     fi


### PR DESCRIPTION
## 内容
アプレンティス Webテスト パスワードマネージャー ステップ2の修正
- accounts.txt内にスペースが含まれる時、正しくユーザー名とパスワードが表示されない不具合を修正した。

## なぜこの不具合が発生したか
forループはスペースを含む文字列を個別の要素として扱うため、accounts.txtの内容を正しく処理できなかった。

## どうやって修正したか
ファイルを一行ずつ処理するwhile readループを使用した。